### PR TITLE
Convert bigdl-llm as the default loader

### DIFF
--- a/modules/models_settings.py
+++ b/modules/models_settings.py
@@ -162,7 +162,7 @@ def infer_loader(model_name, model_settings):
     elif re.match(r'.*-hqq', model_name.lower()):
         return 'HQQ'
     else:
-        loader = 'Transformers'
+        loader = 'BigDL-LLM'
 
     return loader
 

--- a/server.py
+++ b/server.py
@@ -88,7 +88,7 @@ def create_interface():
 
     # Force some events to be triggered on page load
     shared.persistent_interface_state.update({
-        'loader': shared.args.loader or 'Transformers',
+        'loader': shared.args.loader or 'BigDL-LLM',
         'mode': shared.settings['mode'],
         'character_menu': shared.args.character or shared.settings['character'],
         'instruction_template_str': shared.settings['instruction_template_str'],


### PR DESCRIPTION
Set `bigdl-llm` as the default Loader to replace manual switching.