### PR TITLE
Add instruction template for Qwen and chatGLM3

### DIFF
--- a/instruction-templates/ChatGLM3.yaml
+++ b/instruction-templates/ChatGLM3.yaml
@@ -1,0 +1,24 @@
+instruction_template: |-
+  {%- set ns = namespace(found=false) -%}
+  {%- for message in messages -%}
+      {%- if message['role'] == 'system' -%}
+          {%- set ns.found = true -%}
+      {%- endif -%}
+  {%- endfor -%}
+  {%- if not ns.found -%}
+      {{- '' + '' + '' -}}
+  {%- endif %}
+  {%- for message in messages %}
+      {%- if message['role'] == 'system' -%}
+          {{- '<|system|>\n' + message['content'] + '\n' -}}
+      {%- else -%}
+          {%- if message['role'] == 'user' -%}
+              {{-'<|user|>\n' + message['content'] + '\n'-}}
+          {%- else -%}
+              {{-'<|assistant|>\n' + message['content'] + '\n' -}}
+          {%- endif -%}
+      {%- endif -%}
+  {%- endfor -%}
+  {%- if add_generation_prompt -%}
+      {{-'<|assistant|>\n'-}}
+  {%- endif -%}

--- a/instruction-templates/Qwen.yaml
+++ b/instruction-templates/Qwen.yaml
@@ -1,0 +1,24 @@
+instruction_template: |-
+  {%- set ns = namespace(found=false) -%}
+  {%- for message in messages -%}
+      {%- if message['role'] == 'system' -%}
+          {%- set ns.found = true -%}
+      {%- endif -%}
+  {%- endfor -%}
+  {%- if not ns.found -%}
+      {{- '' + '' + '' -}}
+  {%- endif %}
+  {%- for message in messages %}
+      {%- if message['role'] == 'system' -%}
+          {{- '<|im_start|>system\n' + message['content'] + '<|im_end|>\n' -}}
+      {%- else -%}
+          {%- if message['role'] == 'user' -%}
+              {{-'<|im_start|>user\n' + message['content'] + '<|im_end|>\n'-}}
+          {%- else -%}
+              {{-'<|im_start|>assistant\n' + message['content'] + '<|im_end|>\n' -}}
+          {%- endif -%}
+      {%- endif -%}
+  {%- endfor -%}
+  {%- if add_generation_prompt -%}
+      {{-'<|im_start|>assistant\n'-}}
+  {%- endif -%}

--- a/models/config.yaml
+++ b/models/config.yaml
@@ -190,3 +190,5 @@
   instruction_template: 'ChatML'
 .*synthia:
   instruction_template: 'Synthia'
+.*qwen:
+  instruction_template: 'Qwen'

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -314,17 +314,17 @@ def generate_reply_HF(question, original_question, seed, state, stopping_strings
         generate_params.update({'synced_gpus': True})
 
     #tune the prompt based on qwen
-    QWEN_PROMPT_FORMAT = """
-    <|im_start|>system
-    You are a helpful assistant.
-    <|im_end|>
-    <|im_start|>user
-    {prompt}
-    <|im_end|>
-    <|im_start|>assistant
-    """
-    if shared.model.config.model_type == "qwen":
-        question = QWEN_PROMPT_FORMAT.format(prompt=question)
+    # QWEN_PROMPT_FORMAT = """
+    # <|im_start|>system
+    # You are a helpful assistant.
+    # <|im_end|>
+    # <|im_start|>user
+    # {prompt}
+    # <|im_end|>
+    # <|im_start|>assistant
+    # """
+    # if shared.model.config.model_type == "qwen":
+    #     question = QWEN_PROMPT_FORMAT.format(prompt=question)
 
     # Encode the input
     input_ids = encode(question, add_bos_token=state['add_bos_token'], truncation_length=get_max_prompt_length(state))


### PR DESCRIPTION
### Usage:
- Select template from Parameters->Instruction templates -> select template -> load
- Add Custom system message if desired
- Under chat tab, select 'Instruct' option under Mode

###  References used for template format:
Qwen - https://github.com/vllm-project/vllm/issues/1914
ChatGLM3 - https://github.com/THUDM/ChatGLM3/blob/main/PROMPT_en.md
 
### Generated input with formatting tokens
Qwen:
> <|im_start|>system
Your are a helpful assistant.<|im_end|>
<|im_start|>user
What is the capital of France?<|im_end|>
<|im_start|>assistant
The capital of France is Paris.<|im_end|>
<|im_start|>user
What is the capital of Australia?<|im_end|>
<|im_start|>assistant
The capital of Australia is Canberra.<|im_end|>
<|im_start|>user
What is AI?<|im_end|>
<|im_start|>assistant

chatGLM3:
> <|system|>
Your are a helpful assistant.
<|user|>
What is the capital of France?
<|assistant|>
The capital of France is Paris.
<|user|>
What is the capital of Australia?
<|assistant|>
The capital of Australia is Canberra.
<|user|>
What is AI?
<|assistant|>

### Results
Results for Qwen-7b seem to be better than with the hardcoded function.
Results for ChatGLM3-6b seem to be better than with default chat template.