### PR TITLE
Add bigdl-llm loader to bigdl-upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,14 @@ List of command-line flags
 |-------------|-------------|
 | `--hqq-backend` | Backend for the HQQ loader. Valid options: PYTORCH, PYTORCH_COMPILE, ATEN. |
 
+#### IPEX-LLM
+
+| Flag                                  | Description |
+|---------------------------------------|-------------|
+| `--load-in-4bit`   | Load the model with symmetric int4 precision. This option is mutually exclusive with `--load-in-low-bit`. |
+| `--load-in-low-bit PRECISION` | Load the model with specified precision. Supported options are sym_int4, asym_int4, sym_int5, asym_int5, sym_int8, nf3, nf4, fp4, fp8, fp8_e4m3, fp8_e5m2, fp16, and bf16. This option is mutually exclusive with `--load-in-4bit`.|
+
+
 #### DeepSpeed
 
 | Flag                                  | Description |

--- a/modules/loaders.py
+++ b/modules/loaders.py
@@ -156,7 +156,6 @@ loaders_and_params = OrderedDict({
         'bigdl_load_in_4bit',
         'bigdl_load_in_low_bit',
         'optimize_model',
-        'cpu_embedding',
         'trust_remote_code',
         'use_cache',
     ]

--- a/modules/loaders.py
+++ b/modules/loaders.py
@@ -152,9 +152,9 @@ loaders_and_params = OrderedDict({
         'trust_remote_code',
         'no_use_fast',
     ],
-    'BigDL-LLM': [
-        'bigdl_load_in_4bit',
-        'bigdl_load_in_low_bit',
+    'IPEX-LLM': [
+        'ipex_llm_load_in_4bit',
+        'ipex_llm_load_in_low_bit',
         'optimize_model',
         'trust_remote_code',
         'use_cache',
@@ -217,7 +217,7 @@ loaders_samplers = {
     'AutoAWQ': transformers_samplers(),
     'QuIP#': transformers_samplers(),
     'HQQ': transformers_samplers(),
-    'BigDL-LLM': transformers_samplers(),
+    'IPEX-LLM': transformers_samplers(),
     'ExLlamav2': {
         'temperature',
         'temperature_last',

--- a/modules/loaders.py
+++ b/modules/loaders.py
@@ -151,6 +151,14 @@ loaders_and_params = OrderedDict({
         'hqq_backend',
         'trust_remote_code',
         'no_use_fast',
+    ],
+    'BigDL-LLM': [
+        'bigdl_load_in_4bit',
+        'bigdl_load_in_low_bit',
+        'optimize_model',
+        'cpu_embedding',
+        'trust_remote_code',
+        'use_cache',
     ]
 })
 
@@ -210,6 +218,7 @@ loaders_samplers = {
     'AutoAWQ': transformers_samplers(),
     'QuIP#': transformers_samplers(),
     'HQQ': transformers_samplers(),
+    'BigDL-LLM': transformers_samplers(),
     'ExLlamav2': {
         'temperature',
         'temperature_last',

--- a/modules/models.py
+++ b/modules/models.py
@@ -414,7 +414,6 @@ def bigdl_llm_loader(model_name):
                 load_in_4bit=shared.args.load_in_4bit,
                 load_in_low_bit=shared.args.load_in_low_bit,
                 optimize_model=shared.args.optimize_model,
-                cpu_embedding=shared.args.cpu_embedding,
                 trust_remote_code=shared.args.trust_remote_code,
                 use_cache=shared.args.use_cache,
                 )

--- a/modules/models.py
+++ b/modules/models.py
@@ -71,7 +71,7 @@ def load_model(model_name, loader=None):
         'AutoAWQ': AutoAWQ_loader,
         'QuIP#': QuipSharp_loader,
         'HQQ': HQQ_loader,
-        'BigDL-LLM': bigdl_llm_loader,
+        'IPEX-LLM': ipex_llm_loader,
     }
 
     metadata = get_model_metadata(model_name)
@@ -392,9 +392,9 @@ def HQQ_loader(model_name):
     HQQLinear.set_backend(getattr(HQQBackend, shared.args.hqq_backend))
     return model
 
-def bigdl_llm_loader(model_name):
+def ipex_llm_loader(model_name):
 
-    from bigdl.llm.transformers import AutoModelForCausalLM, AutoModel, AutoModelForSeq2SeqLM
+    from ipex_llm.transformers import AutoModelForCausalLM, AutoModel, AutoModelForSeq2SeqLM
 
     path_to_model = Path(f'{shared.args.model_dir}/{model_name}')
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -164,6 +164,18 @@ group.add_argument('--monkey-patch', action='store_true', help='Apply the monkey
 group = parser.add_argument_group('HQQ')
 group.add_argument('--hqq-backend', type=str, default='PYTORCH_COMPILE', help='Backend for the HQQ loader. Valid options: PYTORCH, PYTORCH_COMPILE, ATEN.')
 
+# BigDL-LLM
+group = parser.add_argument_group('BigDL-LLM')
+group.add_argument('--load-in-4bit', action='store_true', default=False, help='boolean value, True means loading linear’s weight to symmetric int 4 if'\
+                   'the model is a regular fp16/bf16/fp32 model, and to asymmetric int 4 if the model is GPTQ model.Default to be False')
+group.add_argument('--load-in-low-bit', type=str, default=None, help='str value, options are sym_int4, asym_int4, sym_int5, asym_int5'\
+                   ', sym_int8, nf3, nf4, fp4, fp8, fp8_e4m3, fp8_e5m2, fp16 or bf16. sym_int4 means symmetric int 4, asym_int4 means asymmetric int 4,'\
+                   'nf4 means 4-bit NormalFloat, etc. Relevant low bit optimizations will be applied to the model.')
+group.add_argument('--optimize-model', action='store_true', default=True, help='boolean value, Whether to further optimize the low_bit llm model.')
+group.add_argument('--cpu-embedding', action='store_true', default=True, help='Whether to replace the Embedding layer, may need to set it to `True` when running BigDL-LLM on GPU on Windows. Default to be `False`')
+group.add_argument('--use-cache', action='store_true', default=True, help='If use_cache is True, past key values are used to speed up decoding if applicable to model.')
+group.add_argument('--trust-remote-code', action='store_true', default=True, help='Set trust_remote_code=True while loading the model. Necessary for some models.')
+
 # DeepSpeed
 group = parser.add_argument_group('DeepSpeed')
 group.add_argument('--deepspeed', action='store_true', help='Enable the use of DeepSpeed ZeRO-3 for inference via the Transformers integration.')
@@ -264,6 +276,8 @@ def fix_loader_name(name):
         return 'QuIP#'
     elif name in ['hqq']:
         return 'HQQ'
+    elif name in ['BigDL-LLM', 'bigdl-llm', 'bigdl']:
+        return 'BigDL-LLM'
 
 
 def add_extension(name, last=False):

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -172,7 +172,6 @@ group.add_argument('--load-in-low-bit', type=str, default=None, help='str value,
                    ', sym_int8, nf3, nf4, fp4, fp8, fp8_e4m3, fp8_e5m2, fp16 or bf16. sym_int4 means symmetric int 4, asym_int4 means asymmetric int 4,'\
                    'nf4 means 4-bit NormalFloat, etc. Relevant low bit optimizations will be applied to the model.')
 group.add_argument('--optimize-model', action='store_true', default=True, help='boolean value, Whether to further optimize the low_bit llm model.')
-group.add_argument('--cpu-embedding', action='store_true', default=True, help='Whether to replace the Embedding layer, may need to set it to `True` when running BigDL-LLM on GPU on Windows. Default to be `False`')
 group.add_argument('--use-cache', action='store_true', default=True, help='If use_cache is True, past key values are used to speed up decoding if applicable to model.')
 group.add_argument('--trust-remote-code', action='store_true', default=True, help='Set trust_remote_code=True while loading the model. Necessary for some models.')
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -164,8 +164,8 @@ group.add_argument('--monkey-patch', action='store_true', help='Apply the monkey
 group = parser.add_argument_group('HQQ')
 group.add_argument('--hqq-backend', type=str, default='PYTORCH_COMPILE', help='Backend for the HQQ loader. Valid options: PYTORCH, PYTORCH_COMPILE, ATEN.')
 
-# BigDL-LLM
-group = parser.add_argument_group('BigDL-LLM')
+# IPEX-LLM
+group = parser.add_argument_group('IPEX-LLM')
 group.add_argument('--load-in-4bit', action='store_true', default=False, help='boolean value, True means loading linear’s weight to symmetric int 4 if'\
                    'the model is a regular fp16/bf16/fp32 model, and to asymmetric int 4 if the model is GPTQ model.Default to be False')
 group.add_argument('--load-in-low-bit', type=str, default=None, help='str value, options are sym_int4, asym_int4, sym_int5, asym_int5'\
@@ -275,8 +275,8 @@ def fix_loader_name(name):
         return 'QuIP#'
     elif name in ['hqq']:
         return 'HQQ'
-    elif name in ['BigDL-LLM', 'bigdl-llm', 'bigdl']:
-        return 'BigDL-LLM'
+    elif name in ['IPEX-LLM', 'ipex-llm']:
+        return 'IPEX-LLM'
 
 
 def add_extension(name, last=False):

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -139,7 +139,7 @@ def encode(prompt, add_special_tokens=True, add_bos_token=True, truncation_lengt
         return input_ids
     elif shared.args.deepspeed:
         return input_ids.to(device=local_rank)
-    elif shared.args.loader == 'BigDL-LLM':
+    elif shared.args.loader == 'IPEX-LLM':
         return input_ids
     elif torch.backends.mps.is_available():
         device = torch.device('mps')

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -139,6 +139,8 @@ def encode(prompt, add_special_tokens=True, add_bos_token=True, truncation_lengt
         return input_ids
     elif shared.args.deepspeed:
         return input_ids.to(device=local_rank)
+    elif shared.args.loader == 'BigDL-LLM':
+        return input_ids
     elif torch.backends.mps.is_available():
         device = torch.device('mps')
         return input_ids.to(device)

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -100,7 +100,6 @@ def list_model_elements():
         'bigdl_load_in_4bit',
         'bigdl_load_in_low_bit',
         'optimize_model',
-        'cpu_embedding',
         'use_cache',
     ]
     if is_torch_xpu_available():

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -97,8 +97,8 @@ def list_model_elements():
         'row_split',
         'tensorcores',
         'hqq_backend',
-        'bigdl_load_in_4bit',
-        'bigdl_load_in_low_bit',
+        'ipex_llm_load_in_4bit',
+        'ipex_llm_load_in_low_bit',
         'optimize_model',
         'use_cache',
     ]

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -97,6 +97,11 @@ def list_model_elements():
         'row_split',
         'tensorcores',
         'hqq_backend',
+        'bigdl_load_in_4bit',
+        'bigdl_load_in_low_bit',
+        'optimize_model',
+        'cpu_embedding',
+        'use_cache',
     ]
     if is_torch_xpu_available():
         for i in range(torch.xpu.device_count()):

--- a/modules/ui_model_menu.py
+++ b/modules/ui_model_menu.py
@@ -109,6 +109,16 @@ def create_ui():
 
                             shared.gradio['autogptq_info'] = gr.Markdown('ExLlamav2_HF is recommended over AutoGPTQ for models derived from Llama.')
                             shared.gradio['quipsharp_info'] = gr.Markdown('QuIP# has to be installed manually at the moment.')
+                            shared.gradio['bigdl_load_in_4bit'] = gr.Checkbox(label="load-in-4bit",
+                                                                        value=shared.args.load_in_4bit,
+                                                                        info="Load linear's weights to symmetric int 4.\n\nTo enable this option, start the web UI with the --load-in-4bit flag.",
+                                                                        interactive=shared.args.load_in_4bit)
+                            shared.gradio['bigdl_load_in_low_bit'] = gr.Dropdown(label="load-in-low-bit",
+                                                                           choices=["sym_int4", "asym_int4", "sym_int5", "asym_int5", "sym_int8",
+                                                                                    "nf3", "nf4", "fp4", "fp8", "fp8_e4m3", "fp8_e5m2", "fp16", "bf16"],
+                                                                           value=shared.args.load_in_low_bit,
+                                                                           info='Apply relevant low bit optimizations to the model.\n\nTo enable this option, start the web UI with the --load-in-low-bit flag.',
+                                                                           interactive=shared.args.load_in_4bit is False)
 
                         with gr.Column():
                             shared.gradio['load_in_8bit'] = gr.Checkbox(label="load-in-8bit", value=shared.args.load_in_8bit)
@@ -146,7 +156,10 @@ def create_ui():
                             shared.gradio['gptq_for_llama_info'] = gr.Markdown('Legacy loader for compatibility with older GPUs. ExLlamav2_HF or AutoGPTQ are preferred for GPTQ models when supported.')
                             shared.gradio['exllamav2_info'] = gr.Markdown("ExLlamav2_HF is recommended over ExLlamav2 for better integration with extensions and more consistent sampling behavior across loaders.")
                             shared.gradio['llamacpp_HF_info'] = gr.Markdown("llamacpp_HF loads llama.cpp as a Transformers model. To use it, you need to place your GGUF in a subfolder of models/ with the necessary tokenizer files.\n\nYou can use the \"llamacpp_HF creator\" menu to do that automatically.")
-
+                            shared.gradio['optimize_model'] = gr.Checkbox(label="optimize-model", value=shared.args.optimize_model, info="Enable this option to further optimize the low-bit llm model.")
+                            shared.gradio['cpu_embedding'] = gr.Checkbox(label="cpu-embedding", value=shared.args.cpu_embedding, info="Whether to replace the Embedding layer.")
+                            shared.gradio['use_cache'] = gr.Checkbox(label="use-cache", value=shared.args.use_cache, info="Wether to use past_key_values to speed up model decoding.")
+                            
             with gr.Column():
                 with gr.Row():
                     shared.gradio['autoload_model'] = gr.Checkbox(value=shared.settings['autoload_model'], label='Autoload the model', info='Whether to load the model as soon as it is selected in the Model dropdown.', interactive=not mu)

--- a/modules/ui_model_menu.py
+++ b/modules/ui_model_menu.py
@@ -109,11 +109,11 @@ def create_ui():
 
                             shared.gradio['autogptq_info'] = gr.Markdown('ExLlamav2_HF is recommended over AutoGPTQ for models derived from Llama.')
                             shared.gradio['quipsharp_info'] = gr.Markdown('QuIP# has to be installed manually at the moment.')
-                            shared.gradio['bigdl_load_in_4bit'] = gr.Checkbox(label="load-in-4bit",
+                            shared.gradio['ipex_llm_load_in_4bit'] = gr.Checkbox(label="load-in-4bit",
                                                                         value=shared.args.load_in_4bit,
                                                                         info="Load linear's weights to symmetric int 4.\n\nTo enable this option, start the web UI with the --load-in-4bit flag.",
                                                                         interactive=shared.args.load_in_4bit)
-                            shared.gradio['bigdl_load_in_low_bit'] = gr.Dropdown(label="load-in-low-bit",
+                            shared.gradio['ipex_llm_load_in_low_bit'] = gr.Dropdown(label="load-in-low-bit",
                                                                            choices=["sym_int4", "asym_int4", "sym_int5", "asym_int5", "sym_int8",
                                                                                     "nf3", "nf4", "fp4", "fp8", "fp8_e4m3", "fp8_e5m2", "fp16", "bf16"],
                                                                            value=shared.args.load_in_low_bit,

--- a/modules/ui_model_menu.py
+++ b/modules/ui_model_menu.py
@@ -157,7 +157,6 @@ def create_ui():
                             shared.gradio['exllamav2_info'] = gr.Markdown("ExLlamav2_HF is recommended over ExLlamav2 for better integration with extensions and more consistent sampling behavior across loaders.")
                             shared.gradio['llamacpp_HF_info'] = gr.Markdown("llamacpp_HF loads llama.cpp as a Transformers model. To use it, you need to place your GGUF in a subfolder of models/ with the necessary tokenizer files.\n\nYou can use the \"llamacpp_HF creator\" menu to do that automatically.")
                             shared.gradio['optimize_model'] = gr.Checkbox(label="optimize-model", value=shared.args.optimize_model, info="Enable this option to further optimize the low-bit llm model.")
-                            shared.gradio['cpu_embedding'] = gr.Checkbox(label="cpu-embedding", value=shared.args.cpu_embedding, info="Whether to replace the Embedding layer.")
                             shared.gradio['use_cache'] = gr.Checkbox(label="use-cache", value=shared.args.use_cache, info="Wether to use past_key_values to speed up model decoding.")
                             
             with gr.Column():

--- a/modules/ui_model_menu.py
+++ b/modules/ui_model_menu.py
@@ -111,13 +111,13 @@ def create_ui():
                             shared.gradio['quipsharp_info'] = gr.Markdown('QuIP# has to be installed manually at the moment.')
                             shared.gradio['ipex_llm_load_in_4bit'] = gr.Checkbox(label="load-in-4bit",
                                                                         value=shared.args.load_in_4bit,
-                                                                        info="Load linear's weights to symmetric int 4.\n\nTo enable this option, start the web UI with the --load-in-4bit flag.",
+                                                                        info="Load the model with symmetric int4 precision.\n\nTo enable this option, start the web UI with the --load-in-4bit flag.",
                                                                         interactive=shared.args.load_in_4bit)
                             shared.gradio['ipex_llm_load_in_low_bit'] = gr.Dropdown(label="load-in-low-bit",
                                                                            choices=["sym_int4", "asym_int4", "sym_int5", "asym_int5", "sym_int8",
                                                                                     "nf3", "nf4", "fp4", "fp8", "fp8_e4m3", "fp8_e5m2", "fp16", "bf16"],
                                                                            value=shared.args.load_in_low_bit,
-                                                                           info='Apply relevant low bit optimizations to the model.\n\nTo enable this option, start the web UI with the --load-in-low-bit flag.',
+                                                                           info='Load the model with specified precision.\n\nTo enable this option, start the web UI with the --load-in-low-bit flag.',
                                                                            interactive=shared.args.load_in_4bit is False)
 
                         with gr.Column():


### PR DESCRIPTION
## Description:
 Add BigDL-LLM loader to upstream main
- Core changes / functionality only
- No GPU support
- Readme to be updated after scope of commit is reviewed

### Environment setup
> pip install --pre --upgrade bigdl-llm[all]
cd \<text-generation-webui\>
> pip install -r requirements_cpu_only.txt

### Run WebUI
> python server.py --load-in-low-bit sym_int4 --share

Note:
- --share is required if program is run on remote server through ssh. If this option is not enabled, an error is thrown.

### Tested models
Successful - chatglm3-6b, mistral-7B-v0.1, qwen-7b-chat, falcon-7b-instruct-with-patch
Fail - llama2-7b-chat-hf. Reason is upstream main's requirements*.txt has updated transformers version to 4.38.2, which is unsupported.
