### PR TITLE
Fix load_in_4bit and load_in_low_bit not taking effect in UI

### DIFF
--- a/modules/loaders.py
+++ b/modules/loaders.py
@@ -153,10 +153,10 @@ loaders_and_params = OrderedDict({
         'no_use_fast',
     ],
     'IPEX-LLM': [
-        'ipex_llm_load_in_4bit',
-        'ipex_llm_load_in_low_bit',
+        'load_in_4bit',
+        'load_in_low_bit',
         'optimize_model',
-        'trust_remote_code',
+        'trust_remote_code'
     ]
 })
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -108,7 +108,7 @@ group.add_argument('--use_flash_attention_2', action='store_true', help='Set use
 
 # bitsandbytes 4-bit
 group = parser.add_argument_group('bitsandbytes 4-bit')
-group.add_argument('--load-in-4bit', action='store_true', help='Load the model with 4-bit precision (using bitsandbytes).')
+group.add_argument('--load-in-4bit', action='store_true', help='Load the model with 4-bit precision (using bitsandbytes or ipex-llm).')
 group.add_argument('--use_double_quant', action='store_true', help='use_double_quant for 4-bit.')
 group.add_argument('--compute_dtype', type=str, default='float16', help='compute dtype for 4-bit. Valid options: bfloat16, float16, float32.')
 group.add_argument('--quant_type', type=str, default='nf4', help='quant_type for 4-bit. Valid options: nf4, fp4.')
@@ -166,7 +166,8 @@ group.add_argument('--hqq-backend', type=str, default='PYTORCH_COMPILE', help='B
 
 # IPEX-LLM
 group = parser.add_argument_group('IPEX-LLM')
-group.add_argument('--load-in-4bit', action='store_true', help='Load the model to symmetric int4 precision if it is a regular fp16/bf16/fp32 model, and to asymmetric int4 precision if it is GPTQ model.')
+# --load-in-4bit is the same as bitsandbytes 4-bit's argument
+# group.add_argument('--load-in-4bit', action='store_true', help='Load the model to symmetric int4 precision if it is a regular fp16/bf16/fp32 model, and to asymmetric int4 precision if it is GPTQ model.')
 group.add_argument('--load-in-low-bit', type=str, default=None, help='Load the model to the specified low-bit precision. Supported options are sym_int4, fp4, fp8, asym_int4, sym_int5, asym_int5, sym_int8, mixed_fp4, mixed_fp8, nf3, nf4, fp8_e4m3, fp16 or bf16. asym_int4 means asymmetric int4, fp8 means 8-bit floating point, mixed_fp8 means mixture of 8-bit quantization, nf4 means 4-bit NormalFloat, etc.')
 group.add_argument('--optimize-model', action='store_true', help='Further optimize the low-bit model with ipex-llm.')
 group.add_argument('--trust-remote-code', action='store_true', help='Set trust_remote_code=True while loading the model. Necessary for some models.')

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -97,8 +97,7 @@ def list_model_elements():
         'row_split',
         'tensorcores',
         'hqq_backend',
-        'ipex_llm_load_in_4bit',
-        'ipex_llm_load_in_low_bit',
+        'load_in_low_bit',
         'optimize_model'
     ]
     if is_torch_xpu_available():

--- a/modules/ui_model_menu.py
+++ b/modules/ui_model_menu.py
@@ -109,12 +109,12 @@ def create_ui():
 
                             shared.gradio['autogptq_info'] = gr.Markdown('ExLlamav2_HF is recommended over AutoGPTQ for models derived from Llama.')
                             shared.gradio['quipsharp_info'] = gr.Markdown('QuIP# has to be installed manually at the moment.')
-                            shared.gradio['ipex_llm_load_in_4bit'] = gr.Checkbox(label="load-in-4bit", value=shared.args.load_in_4bit, info="Load the model to symmetric int4 precision.\n\nTo enable this option, start the web UI with the --load-in-4bit flag.", interactive=shared.args.load_in_4bit)
-                            shared.gradio['ipex_llm_load_in_low_bit'] = gr.Dropdown(label="load-in-low-bit", choices=["sym_int4", "fp4", "fp8", "asym_int4", "sym_int5", "asym_int5", "sym_int8", "nf3", "nf4", "fp8_e4m3", "fp16", "bf16"], value=shared.args.load_in_low_bit, info='Load the model to the specified low-bit precision.\n\nTo enable this option, start the web UI with the argument --load-in-low-bit PRECISION.', interactive=not shared.args.load_in_4bit)
+                            shared.gradio['load_in_low_bit'] = gr.Dropdown(label="load-in-low-bit", choices=["sym_int4", "fp4", "fp8", "asym_int4", "sym_int5", "asym_int5", "sym_int8", "nf3", "nf4", "fp8_e4m3", "fp16", "bf16"], value=shared.args.load_in_low_bit, info='Load the model to the specified low-bit precision.', interactive=not shared.args.load_in_4bit)
+                            shared.gradio['optimize_model'] = gr.Checkbox(label="optimize-model", value=shared.args.optimize_model, info="Further optimize the low-bit model with ipex-llm.")
 
                         with gr.Column():
                             shared.gradio['load_in_8bit'] = gr.Checkbox(label="load-in-8bit", value=shared.args.load_in_8bit)
-                            shared.gradio['load_in_4bit'] = gr.Checkbox(label="load-in-4bit", value=shared.args.load_in_4bit)
+                            shared.gradio['load_in_4bit'] = gr.Checkbox(label="load-in-4bit", value=shared.args.load_in_4bit, info="Load the model with 4-bit precision.", interactive=not shared.args.load_in_low_bit)
                             shared.gradio['use_double_quant'] = gr.Checkbox(label="use_double_quant", value=shared.args.use_double_quant)
                             shared.gradio['use_flash_attention_2'] = gr.Checkbox(label="use_flash_attention_2", value=shared.args.use_flash_attention_2, info='Set use_flash_attention_2=True while loading the model.')
                             shared.gradio['auto_devices'] = gr.Checkbox(label="auto-devices", value=shared.args.auto_devices)
@@ -138,7 +138,6 @@ def create_ui():
                             shared.gradio['no_flash_attn'] = gr.Checkbox(label="no_flash_attn", value=shared.args.no_flash_attn, info='Force flash-attention to not be used.')
                             shared.gradio['cfg_cache'] = gr.Checkbox(label="cfg-cache", value=shared.args.cfg_cache, info='Necessary to use CFG with this loader.')
                             shared.gradio['num_experts_per_token'] = gr.Number(label="Number of experts per token", value=shared.args.num_experts_per_token, info='Only applies to MoE models like Mixtral.')
-                            shared.gradio['optimize_model'] = gr.Checkbox(label="optimize-model", value=shared.args.optimize_model, info="Further optimize the low-bit model with ipex-llm.")
                             with gr.Blocks():
                                 shared.gradio['trust_remote_code'] = gr.Checkbox(label="trust-remote-code", value=shared.args.trust_remote_code, info='Set trust_remote_code=True while loading the tokenizer/model. To enable this option, start the web UI with the --trust-remote-code flag.', interactive=shared.args.trust_remote_code)
                                 shared.gradio['no_use_fast'] = gr.Checkbox(label="no_use_fast", value=shared.args.no_use_fast, info='Set use_fast=False while loading the tokenizer.')


### PR DESCRIPTION
Currently with variable names `ipex_llm_load_in_4bit` or `ipex_llm_load_in_low_bit`, when modifying their values in the UI (unchecking load_in_4bit or change values for low-bit), the modified values won't take effect in the actual code. Seems in this way the values can't be modified after the webui is launched (either with the argument value or the default value if not specified).

Changing the variable name resolves the problem.

Using the same argument `--load-in-4bit` as bitsandbytes.