### PR TITLE
Add dependency to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,8 @@ tensorboard
 transformers==4.38.*
 tqdm
 wandb
+py-cpuinfo
+ipex-llm
 
 # bitsandbytes
 bitsandbytes==0.42.*; platform_system != "Windows"

--- a/requirements_cpu_only.txt
+++ b/requirements_cpu_only.txt
@@ -22,6 +22,8 @@ tensorboard
 transformers==4.38.*
 tqdm
 wandb
+py-cpuinfo
+ipex-llm
 
 # llama-cpp-python (CPU only, AVX2)
 https://github.com/oobabooga/llama-cpp-python-cuBLAS-wheels/releases/download/cpu/llama_cpp_python-0.2.52+cpuavx2-cp311-cp311-manylinux_2_31_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64" and python_version == "3.11"

--- a/requirements_cpu_only_noavx2.txt
+++ b/requirements_cpu_only_noavx2.txt
@@ -22,6 +22,8 @@ tensorboard
 transformers==4.38.*
 tqdm
 wandb
+py-cpuinfo
+ipex-llm
 
 # llama-cpp-python (CPU only, no AVX2)
 https://github.com/oobabooga/llama-cpp-python-cuBLAS-wheels/releases/download/cpu/llama_cpp_python-0.2.52+cpuavx-cp311-cp311-manylinux_2_31_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64" and python_version == "3.11"

--- a/requirements_noavx2.txt
+++ b/requirements_noavx2.txt
@@ -22,6 +22,8 @@ tensorboard
 transformers==4.38.*
 tqdm
 wandb
+py-cpuinfo
+ipex-llm
 
 # bitsandbytes
 bitsandbytes==0.42.*; platform_system != "Windows"

--- a/requirements_nowheels.txt
+++ b/requirements_nowheels.txt
@@ -22,3 +22,5 @@ tensorboard
 transformers==4.38.*
 tqdm
 wandb
+py-cpuinfo
+ipex-llm


### PR DESCRIPTION
Do not use ipex-llm[all] since there are dependency conflicts.
Only use ipex-llm and the missing dependency py-cpuinfo here.